### PR TITLE
fix(cicd-common): handle null runtime in slow test report jq query

### DIFF
--- a/src/practices/cicd-common/best-practice/.github/workflows/.test.yml
+++ b/src/practices/cicd-common/best-practice/.github/workflows/.test.yml
@@ -244,7 +244,7 @@ jobs:
         if: always() && hashFiles('jest-results.json') != ''
         run: |
           set -eu
-          jq -r '.testResults[] | "\(.name):\(.perfStats.runtime)"' jest-results.json | while IFS=: read -r name runtime; do
+          jq -r '.testResults[] | select(.perfStats.runtime != null) | "\(.name):\(.perfStats.runtime)"' jest-results.json | while IFS=: read -r name runtime; do
             seconds=$((runtime / 1000))
             if [[ $seconds -ge 30 ]]; then
               echo "::warning file=${name}::slow test: ${seconds}s"
@@ -318,7 +318,7 @@ jobs:
         if: always() && hashFiles('jest-results.json') != ''
         run: |
           set -eu
-          jq -r '.testResults[] | "\(.name):\(.perfStats.runtime)"' jest-results.json | while IFS=: read -r name runtime; do
+          jq -r '.testResults[] | select(.perfStats.runtime != null) | "\(.name):\(.perfStats.runtime)"' jest-results.json | while IFS=: read -r name runtime; do
             seconds=$((runtime / 1000))
             if [[ $seconds -ge 30 ]]; then
               echo "::warning file=${name}::slow test: ${seconds}s"


### PR DESCRIPTION
fix(cicd-common): handle null runtime in slow test report jq query

- added select(.perfStats.runtime != null) filter to skip tests without runtime stats
- fixes jq error when perfStats.runtime is null

---
🐢🌊 surfed in by seaturtle[bot]