### PR TITLE
fix(practices): add .dpdmrc.yaml for dpdm exclude patterns

### DIFF
--- a/src/practices/lint/best-practice/.dpdmrc.yaml
+++ b/src/practices/lint/best-practice/.dpdmrc.yaml
@@ -1,0 +1,6 @@
+# dpdm exclude patterns
+# each entry is joined with | to form a single regex for --exclude
+#
+# only exclude devDependencies here
+# if you exclude a prod dependency, you ship cycles to consumers and break their builds
+exclude: []

--- a/src/practices/lint/best-practice/package.json
+++ b/src/practices/lint/best-practice/package.json
@@ -10,7 +10,7 @@
     "test:format:biome": "biome format",
     "test:lint:biome": "biome check --diagnostic-level=error",
     "test:lint:biome:all": "biome check",
-    "test:lint:cycles": "dpdm --no-warning --no-tree --exit-code circular:1 --exclude '^$' 'src/**/*.ts'",
+    "test:lint:cycles": "dpdm --no-warning --no-tree --exit-code circular:1 --exclude \"$(yq -r '.exclude | if length > 0 then join(\"|\") else \"^$\" end' .dpdmrc.yaml)\" 'src/**/*.ts'",
     "test:lint:deps": "npx depcheck -c ./.depcheckrc.yml",
     "test:lint": "npm run test:lint:biome && npm run test:lint:cycles && npm run test:lint:deps"
   }


### PR DESCRIPTION
fix(practices): add .dpdmrc.yaml for dpdm exclude patterns

- add .dpdmrc.yaml to manage cycle detection excludes declaratively
- update test:lint:cycles to parse config with yq
- only devDependencies should be excluded (prod cycles break consumers)

---
🐢🌊 surfed in by seaturtle[bot]