### PR TITLE
fix(practices): use releasers team for production-on-else environment

### DIFF
--- a/src/practices/environments/bad-practices/old-stage-enum/src/**/*.ts.declapract.ts
+++ b/src/practices/environments/bad-practices/old-stage-enum/src/**/*.ts.declapract.ts
@@ -17,7 +17,7 @@ export const check: FileCheckFunction = (contents) => {
 export const fix: FileFixFunction = (contents) => {
   if (!contents) return { contents };
 
-  let fixed = contents
+  const fixed = contents
     // replace enum values with string literals
     .replace(/Stage\.PRODUCTION/g, "'prod'")
     .replace(/Stage\.DEVELOPMENT/g, "'prep'")

--- a/src/practices/provision-github/bad-practices/deprecated-reviewers-variable/__snapshots__/declapract.use.yml.declapract.test.ts.snap
+++ b/src/practices/provision-github/bad-practices/deprecated-reviewers-variable/__snapshots__/declapract.use.yml.declapract.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`deprecated-reviewers-variable declapract.use.yml given: [case1] declapract.use.yml with reviewers variable when: [t1] fix is called then: it should remove the reviewers variable 1`] = `
+"# declapract.use.yml
+declarations: ./
+useCase: npm-package
+variables:
+  organizationName: 'ehmpathy'
+  projectName: 'some-project'
+"
+`;

--- a/src/practices/provision-github/bad-practices/deprecated-reviewers-variable/declapract.use.yml.declapract.test.ts
+++ b/src/practices/provision-github/bad-practices/deprecated-reviewers-variable/declapract.use.yml.declapract.test.ts
@@ -1,0 +1,60 @@
+import { given, then, when } from 'test-fns';
+
+import { check, fix } from './declapract.use.yml.declapract';
+
+describe('deprecated-reviewers-variable declapract.use.yml', () => {
+  given('[case1] declapract.use.yml with reviewers variable', () => {
+    const contents = `# declapract.use.yml
+declarations: ./
+useCase: npm-package
+variables:
+  organizationName: 'ehmpathy'
+  projectName: 'some-project'
+  reviewers:
+    users:
+      - uladkasach
+`;
+
+    when('[t0] check is called', () => {
+      then('it should detect the bad practice', () => {
+        expect(() => check(contents, {} as any)).not.toThrow();
+      });
+    });
+
+    when('[t1] fix is called', () => {
+      then('it should remove the reviewers variable', async () => {
+        const result = await fix(contents, {} as any);
+        expect(result.contents).not.toContain('reviewers');
+        expect(result.contents).toContain('organizationName');
+        expect(result.contents).toContain('projectName');
+        expect(result.contents).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case2] declapract.use.yml without reviewers variable', () => {
+    const contents = `# declapract.use.yml
+declarations: ./
+useCase: npm-package
+variables:
+  organizationName: 'ehmpathy'
+  projectName: 'some-project'
+`;
+
+    when('[t0] check is called', () => {
+      then('it should not detect the bad practice', () => {
+        expect(() => check(contents, {} as any)).toThrow(
+          'no deprecated reviewers variable found',
+        );
+      });
+    });
+  });
+
+  given('[case3] no file', () => {
+    when('[t0] check is called with null', () => {
+      then('it should throw', () => {
+        expect(() => check(null, {} as any)).toThrow('no file found');
+      });
+    });
+  });
+});

--- a/src/practices/provision-github/bad-practices/deprecated-reviewers-variable/declapract.use.yml.declapract.ts
+++ b/src/practices/provision-github/bad-practices/deprecated-reviewers-variable/declapract.use.yml.declapract.ts
@@ -9,7 +9,9 @@ import yaml from 'yaml';
 export const check: FileCheckFunction = (contents) => {
   if (!contents) throw new Error('no file found');
 
-  const parsed = yaml.parse(contents) as { variables?: Record<string, unknown> };
+  const parsed = yaml.parse(contents) as {
+    variables?: Record<string, unknown>;
+  };
   const variables = parsed?.variables ?? {};
 
   // check if reviewers or reviewers.users exists

--- a/src/practices/provision-github/bad-practices/deprecated-reviewers-variable/declapract.use.yml.declapract.ts
+++ b/src/practices/provision-github/bad-practices/deprecated-reviewers-variable/declapract.use.yml.declapract.ts
@@ -1,0 +1,39 @@
+import type { FileCheckFunction, FileFixFunction } from 'declapract';
+import yaml from 'yaml';
+
+/**
+ * .what = removes deprecated reviewers.users variable from declapract.use.yml
+ * .why = production-on-else environment now uses team:releaser instead of user list
+ */
+
+export const check: FileCheckFunction = (contents) => {
+  if (!contents) throw new Error('no file found');
+
+  const parsed = yaml.parse(contents) as { variables?: Record<string, unknown> };
+  const variables = parsed?.variables ?? {};
+
+  // check if reviewers or reviewers.users exists
+  if ('reviewers' in variables) return; // bad practice detected
+
+  throw new Error('no deprecated reviewers variable found');
+};
+
+export const fix: FileFixFunction = (contents) => {
+  if (!contents) return { contents };
+
+  // parse with parseDocument to preserve comments and format
+  const doc = yaml.parseDocument(contents);
+  const parsed = doc.toJSON() as { variables?: Record<string, unknown> };
+
+  if (!parsed?.variables || !('reviewers' in parsed.variables)) {
+    return { contents };
+  }
+
+  // remove the reviewers key from variables
+  const variablesNode = doc.get('variables') as yaml.YAMLMap | undefined;
+  if (variablesNode) {
+    variablesNode.delete('reviewers');
+  }
+
+  return { contents: doc.toString() };
+};

--- a/src/practices/provision-github/best-practice/provision/github.repo/resources.ts
+++ b/src/practices/provision-github/best-practice/provision/github.repo/resources.ts
@@ -134,7 +134,7 @@ export const getResources = async (): Promise<DomainEntity<any>[]> => {
   const envProductionOnElse = DeclaredGithubEnvironment.as({
     repo,
     name: 'production-on-else',
-    reviewers: { users: @declapract{variable.reviewers.users}, teams: null },
+    reviewers: { users: null, teams: ['releasers'] },
     waitTimer: null, // no delay once approved
     deploymentBranchPolicy: null, // any branch
     preventSelfReview: false, // self-approval allowed if in reviewers list


### PR DESCRIPTION
fix(practices): use releasers team for production-on-else environment

- replace variable reviewers.users with hardcoded team releasers
- add bad-practice to auto-remove deprecated reviewers variable from repos

---
🐢🌊 surfed in by seaturtle[bot]