### PR TITLE
fix(practices): simplify yq syntax and add typed package.json import

### DIFF
--- a/src/practices/lint/best-practice/package.json
+++ b/src/practices/lint/best-practice/package.json
@@ -10,7 +10,7 @@
     "test:format:biome": "biome format",
     "test:lint:biome": "biome check --diagnostic-level=error",
     "test:lint:biome:all": "biome check",
-    "test:lint:cycles": "dpdm --no-warning --no-tree --exit-code circular:1 --exclude \"$(yq -r '.exclude | if length > 0 then join(\"|\") else \"^$\" end' .dpdmrc.yaml)\" 'src/**/*.ts'",
+    "test:lint:cycles": "dpdm --no-warning --no-tree --exit-code circular:1 --exclude \"$(yq -r '.exclude | join(\"|\") // \"^$\"' .dpdmrc.yaml)\" 'src/**/*.ts'",
     "test:lint:deps": "npx depcheck -c ./.depcheckrc.yml",
     "test:lint": "npm run test:lint:biome && npm run test:lint:cycles && npm run test:lint:deps"
   }

--- a/src/practices/provision-github/best-practice/provision/github.repo/resources.ts
+++ b/src/practices/provision-github/best-practice/provision/github.repo/resources.ts
@@ -10,7 +10,13 @@ import {
 import { type DomainEntity, RefByUnique } from 'domain-objects';
 import { UnexpectedCodePathError } from 'helpful-errors';
 
-import pkg from '../../package.json';
+import pkgJson from '../../package.json';
+
+const pkg = pkgJson as {
+  description?: string;
+  private?: boolean;
+  homepage?: string;
+};
 
 export const getProviders = async (): Promise<DeclastructProvider[]> => [
   getDeclastructGithubProvider(


### PR DESCRIPTION
fix(practices): simplify yq syntax and add typed package.json import

- use concise yq alternative operator syntax for dpdm exclude pattern
- add explicit type for package.json import in github provision resources

---
🐢🌊 surfed in by seaturtle[bot]