### PR TITLE
feat(practices): add cache practice with ifPresent version checks

### DIFF
--- a/.agent/keyrack.yml
+++ b/.agent/keyrack.yml
@@ -1,5 +1,7 @@
 org: ehmpathy
 extends:
+  - .agent/repo=bhrain/role=reviewer/keyrack.yml
+  - .agent/repo=bhuild/role=dispatcher/keyrack.yml
   - .agent/repo=ehmpathy/role=mechanic/keyrack.yml
 env.prod: null
 env.prep: null

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,6 +81,12 @@
             "command": "./node_modules/.bin/rhachet roles boot --role dreamer",
             "timeout": 10,
             "author": "repo=bhuild/role=dreamer"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --role dispatcher",
+            "timeout": 10,
+            "author": "repo=bhuild/role=dispatcher"
           }
         ]
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "preversion": "npm run prepush",
     "postversion": "git push origin HEAD --tags --no-verify",
     "prepare:husky": "husky install && chmod ug+x .husky/*",
-    "prepare:rhachet": "rhachet init --hooks --roles mechanic behaver driver reviewer librarian ergonomist architect reflector dreamer",
+    "prepare:rhachet": "rhachet init --hooks --roles mechanic behaver driver architect ergonomist reviewer dreamer dispatcher",
     "prepare": "if [ -e .git ] && [ -z \"${CI:-}\" ]; then npm run prepare:husky && npm run prepare:rhachet; fi"
   },
   "dependencies": {
@@ -55,7 +55,7 @@
     "yaml": "2.8.2"
   },
   "peerDependencies": {
-    "declapract": ">=0.13.16"
+    "declapract": ">=0.13.22"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      declapract:
-        specifier: '>=0.13.16'
-        version: 0.13.16
       domain-objects:
         specifier: 0.31.9
         version: 0.31.9
@@ -63,6 +60,9 @@ importers:
       cz-conventional-changelog:
         specifier: 3.3.0
         version: 3.3.0(@types/node@22.15.21)(typescript@5.4.5)
+      declapract:
+        specifier: 0.13.22
+        version: 0.13.22
       declastruct:
         specifier: 1.9.1
         version: 1.9.1(domain-objects@0.31.9)
@@ -2694,8 +2694,8 @@ packages:
       supports-color:
         optional: true
 
-  declapract@0.13.16:
-    resolution: {integrity: sha512-mjECXcP0V+ZPuOvaVSnr0cAN2A3XYpGzPBT7ODAOliy266LNWLEoWpfLrrFjL3xb2R72BCptUsUU2Y7FN1bSzw==}
+  declapract@0.13.22:
+    resolution: {integrity: sha512-ZKbQZswU4ilYdy9ue7rnX1a4Ga4wM8aDMWCH9IM1Ya/5hT1bd43KOBodiXEh5bRRwFV4eq9bNEYcl3t9sTprNg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -2798,6 +2798,10 @@ packages:
 
   domain-objects@0.31.10:
     resolution: {integrity: sha512-5Bk53LAVvcLBPeTGaBKBdvXwSzpfKk2t9BDnPP4eSuENl7qdXf+eVk3zeSfxPUygKSgZPN1z1o4QQZIcw85vKw==}
+    engines: {node: '>=8.0.0'}
+
+  domain-objects@0.31.11:
+    resolution: {integrity: sha512-jRHVFk8ZM1ObkSBtSM5QrygqWOBh66dBZm4iuFGdTGv3gotPvBZKASe3eXSBdBWXsL+ahdF2h+OdqD0IAnJVcg==}
     engines: {node: '>=8.0.0'}
 
   domain-objects@0.31.3:
@@ -3377,6 +3381,10 @@ packages:
 
   iso-time@1.11.4:
     resolution: {integrity: sha512-syKeGLYBiiyuHZ9KStPo27uBaxiHRhMYtFxhfdUQGTyR1mGMscBi+ybrScClzb0yFpOCpJpg3XqrT9SVV57OBg==}
+    engines: {node: '>=8.0.0'}
+
+  iso-time@1.11.7:
+    resolution: {integrity: sha512-61n196r6r/Zl9wg6S/GIz6f0VHXikh/9Fq8UikspUzakhjpIxsObnNkkv3WfPcfFpl3RjocyNHwt2qK7xhZC4Q==}
     engines: {node: '>=8.0.0'}
 
   istanbul-lib-coverage@3.2.2:
@@ -4401,6 +4409,10 @@ packages:
     resolution: {integrity: sha512-POHiGnZqnQSivzgSDJfVE3/GAVPUEG0zc5vRLKIPpTnIQ6IY0QhOJOO3Ur0rKgXzwU/hlYpqabkELR62CauMhA==}
     engines: {node: '>=8.0.0'}
 
+  simple-log-methods@0.6.12:
+    resolution: {integrity: sha512-aRkzbdFaOe2KdLyFq6H6aaNsAOoNO56krtBTpB4Lbw8GXX950Vt/hlZ7rCdcBRDxMW84xQOl1ozaYO2eqKERgg==}
+    engines: {node: '>=8.0.0'}
+
   simple-log-methods@0.6.2:
     resolution: {integrity: sha512-wzlQbbT7Emv3N3+iCeukKtQHMM6mPndg9CqzOppQnm4jEPNiaSJUkYz2wM3oOu7Q1RlLwt3qO02oPGBrZ4JLnw==}
     engines: {node: '>=8.0.0'}
@@ -4699,6 +4711,7 @@ packages:
 
   uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -8038,17 +8051,17 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  declapract@0.13.16:
+  declapract@0.13.22:
     dependencies:
       chalk: 2.4.2
       commander: 12.1.0
       cross-path-sort: 1.0.0
-      domain-objects: 0.31.9
+      domain-objects: 0.31.11
       expect: 29.4.3
       find-nearest-package-json: 2.0.1
       flat: 5.0.2
       glob: 11.0.1
-      helpful-errors: 1.5.3
+      helpful-errors: 1.7.3
       indent-string: 4.0.0
       jest-diff: 29.4.3
       joi: 17.4.0
@@ -8056,9 +8069,9 @@ snapshots:
       lodash.uniqby: 4.7.0
       semver: 7.7.1
       shelljs: 0.8.5
-      simple-log-methods: 0.6.9
+      simple-log-methods: 0.6.12
       tsx: 4.20.6
-      type-fns: 1.21.0
+      type-fns: 1.21.2
       uuid: 9.0.0
       yaml: 1.6.0
 
@@ -8191,6 +8204,13 @@ snapshots:
       change-case: 4.1.2
       helpful-errors: 1.7.2
       type-fns: 1.21.0
+      uuid-fns: 1.1.3
+
+  domain-objects@0.31.11:
+    dependencies:
+      change-case: 4.1.2
+      helpful-errors: 1.7.3
+      type-fns: 1.21.2
       uuid-fns: 1.1.3
 
   domain-objects@0.31.3:
@@ -8856,6 +8876,15 @@ snapshots:
       helpful-errors: 1.5.3
       simple-log-methods: 0.6.9
       type-fns: 1.21.0
+
+  iso-time@1.11.7:
+    dependencies:
+      date-fns: 3.6.0
+      domain-glossaries: 1.0.0
+      domain-objects: 0.31.11
+      helpful-errors: 1.7.3
+      simple-log-methods: 0.6.12
+      type-fns: 1.21.2
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -10156,6 +10185,15 @@ snapshots:
       '@ehmpathy/error-fns': 1.3.7
       '@ehmpathy/uni-time': 1.9.1
       domain-glossary-procedure: 1.0.0
+      type-fns: 1.21.2
+
+  simple-log-methods@0.6.12:
+    dependencies:
+      '@ehmpathy/error-fns': 1.3.7
+      domain-glossary-procedure: 1.0.0
+      domain-objects: 0.31.10
+      helpful-errors: 1.7.3
+      iso-time: 1.11.7
       type-fns: 1.21.2
 
   simple-log-methods@0.6.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      declapract:
+        specifier: '>=0.13.22'
+        version: 0.13.22
       domain-objects:
         specifier: 0.31.9
         version: 0.31.9
@@ -60,9 +63,6 @@ importers:
       cz-conventional-changelog:
         specifier: 3.3.0
         version: 3.3.0(@types/node@22.15.21)(typescript@5.4.5)
-      declapract:
-        specifier: 0.13.22
-        version: 0.13.22
       declastruct:
         specifier: 1.9.1
         version: 1.9.1(domain-objects@0.31.9)

--- a/src/practices/cache/best-practice/package.json
+++ b/src/practices/cache/best-practice/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "simple-in-memory-cache": "@declapract{check.minVersion('0.4.3').ifPresent()}",
+    "simple-on-disk-cache": "@declapract{check.minVersion('1.7.10').ifPresent()}",
+    "with-simple-cache": "@declapract{check.minVersion('0.16.2').ifPresent()}"
+  }
+}

--- a/src/practices/config/best-practice/package.json
+++ b/src/practices/config/best-practice/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "sdk-config": "@declapract{check.minVersion('0.1.1')}",
-    "simple-in-memory-cache": "@declapract{check.minVersion('0.4.0')}",
     "zod": "@declapract{check.minVersion('4.0.0')}"
   }
 }

--- a/src/practices/dates-and-times/bad-practices/uni-time/package.json
+++ b/src/practices/dates-and-times/bad-practices/uni-time/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@ehmpathy/uni-time": "@declapract{check.minVersion('0.0.0')}"
+  }
+}

--- a/src/practices/dates-and-times/bad-practices/uni-time/package.json.declapract.test.ts
+++ b/src/practices/dates-and-times/bad-practices/uni-time/package.json.declapract.test.ts
@@ -1,0 +1,70 @@
+import { fix } from './package.json.declapract';
+
+describe('uni-time bad practice package.json', () => {
+  it('should remove @ehmpathy/uni-time from dependencies', async () => {
+    const contents = JSON.stringify(
+      {
+        dependencies: {
+          '@ehmpathy/uni-time': '1.0.0',
+          'other-package': '2.0.0',
+        },
+        devDependencies: {
+          jest: '29.3.1',
+        },
+      },
+      null,
+      2,
+    );
+
+    const { contents: fixed } = await fix(contents, {} as any);
+    const parsed = JSON.parse(fixed!);
+
+    expect(parsed.dependencies['@ehmpathy/uni-time']).toBeUndefined();
+    expect(parsed.dependencies['other-package']).toBe('2.0.0');
+    expect(parsed.devDependencies.jest).toBe('29.3.1');
+  });
+
+  it('should remove @ehmpathy/uni-time from devDependencies', async () => {
+    const contents = JSON.stringify(
+      {
+        dependencies: {
+          'other-package': '2.0.0',
+        },
+        devDependencies: {
+          '@ehmpathy/uni-time': '1.0.0',
+          jest: '29.3.1',
+        },
+      },
+      null,
+      2,
+    );
+
+    const { contents: fixed } = await fix(contents, {} as any);
+    const parsed = JSON.parse(fixed!);
+
+    expect(parsed.devDependencies['@ehmpathy/uni-time']).toBeUndefined();
+    expect(parsed.devDependencies.jest).toBe('29.3.1');
+    expect(parsed.dependencies['other-package']).toBe('2.0.0');
+  });
+
+  it('should remove @ehmpathy/uni-time from both dependencies and devDependencies', async () => {
+    const contents = JSON.stringify(
+      {
+        dependencies: {
+          '@ehmpathy/uni-time': '1.0.0',
+        },
+        devDependencies: {
+          '@ehmpathy/uni-time': '1.0.0',
+        },
+      },
+      null,
+      2,
+    );
+
+    const { contents: fixed } = await fix(contents, {} as any);
+    const parsed = JSON.parse(fixed!);
+
+    expect(parsed.dependencies['@ehmpathy/uni-time']).toBeUndefined();
+    expect(parsed.devDependencies['@ehmpathy/uni-time']).toBeUndefined();
+  });
+});

--- a/src/practices/dates-and-times/bad-practices/uni-time/package.json.declapract.ts
+++ b/src/practices/dates-and-times/bad-practices/uni-time/package.json.declapract.ts
@@ -1,0 +1,23 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { FileCheckType, type FileFixFunction } from 'declapract';
+
+export const check = FileCheckType.CONTAINS;
+
+export const fix: FileFixFunction = (contents) => {
+  if (!contents) return { contents }; // pass through if contents absent
+  const packageJSON = JSON.parse(contents);
+  const updatedPackageJSON = {
+    ...packageJSON,
+    dependencies: {
+      ...packageJSON.dependencies,
+      '@ehmpathy/uni-time': undefined,
+    },
+    devDependencies: {
+      ...packageJSON.devDependencies,
+      '@ehmpathy/uni-time': undefined,
+    },
+  };
+  return {
+    contents: JSON.stringify(updatedPackageJSON, null, 2),
+  };
+};

--- a/src/practices/dates-and-times/bad-practices/uni-time/src/**/*.ts.declapract.test.ts
+++ b/src/practices/dates-and-times/bad-practices/uni-time/src/**/*.ts.declapract.test.ts
@@ -1,0 +1,32 @@
+import { check, fix } from './*.ts.declapract';
+
+describe('uni-time bad practice source files', () => {
+  it('should match files that import from @ehmpathy/uni-time', () => {
+    const contents = `import { IsoDateTime } from '@ehmpathy/uni-time';`;
+    expect(() => check(contents, {} as any)).not.toThrow();
+  });
+
+  it('should not match files without @ehmpathy/uni-time imports', () => {
+    const contents = `import { IsoDateTime } from 'iso-time';`;
+    expect(() => check(contents, {} as any)).toThrow('does not match bad practice');
+  });
+
+  it('should replace @ehmpathy/uni-time imports with iso-time', async () => {
+    const contents = `import { IsoDateTime } from '@ehmpathy/uni-time';`;
+    const { contents: fixed } = await fix(contents, {} as any);
+
+    expect(fixed).toContain("from 'iso-time'");
+    expect(fixed).not.toContain('@ehmpathy/uni-time');
+  });
+
+  it('should replace multiple @ehmpathy/uni-time imports', async () => {
+    const contents = `
+import { IsoDateTime } from '@ehmpathy/uni-time';
+import { IsoDate } from '@ehmpathy/uni-time';
+`;
+    const { contents: fixed } = await fix(contents, {} as any);
+
+    expect(fixed).not.toContain('@ehmpathy/uni-time');
+    expect(fixed?.match(/from 'iso-time'/g)?.length).toBe(2);
+  });
+});

--- a/src/practices/dates-and-times/bad-practices/uni-time/src/**/*.ts.declapract.ts
+++ b/src/practices/dates-and-times/bad-practices/uni-time/src/**/*.ts.declapract.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type { FileCheckFunction, FileFixFunction } from 'declapract';
+
+export const check: FileCheckFunction = (contents) => {
+  if (contents?.includes("from '@ehmpathy/uni-time'")) return; // matches if it includes this
+  throw new Error('does not match bad practice'); // does not otherwise
+};
+
+export const fix: FileFixFunction = (contents) => {
+  if (!contents) return {}; // pass through if contents absent
+  return {
+    contents: contents.replace(
+      /from '@ehmpathy\/uni-time'/g,
+      "from 'iso-time'",
+    ),
+  };
+};

--- a/src/practices/domain/best-practice/package.json
+++ b/src/practices/domain/best-practice/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "domain-objects": "@declapract{check.minVersion('0.31.9')}",
-    "type-fns": "@declapract{check.minVersion('1.21.2')}"
+    "domain-objects": "@declapract{check.minVersion('0.31.13')}",
+    "type-fns": "@declapract{check.minVersion('1.21.3')}"
   }
 }

--- a/src/practices/lint/best-practice/.depcheckrc.yml
+++ b/src/practices/lint/best-practice/.depcheckrc.yml
@@ -7,6 +7,7 @@ ignores:
   - rhachet-roles-bhrain
   - rhachet-roles-bhuild
   - rhachet-roles-ehmpathy
+  - rhachet-roles-rhachet
   - declapract
   - declapract-typescript-ehmpathy
   - "@commitlint/config-conventional"
@@ -20,3 +21,5 @@ ignores:
   - tsx
   - tsc-alias
   - yalc
+  - test-fns
+  - type-fns

--- a/src/useCases.yml
+++ b/src/useCases.yml
@@ -2,6 +2,7 @@
 use-cases:
   typescript-project:
     practices:
+      - cache
       - cicd-common
       - conventional-commits
       - husky


### PR DESCRIPTION
feat(practices): add cache practice with ifPresent version checks

- add cache best-practice with minVersion().ifPresent() for optional deps
- simple-in-memory-cache >= 0.4.3
- simple-on-disk-cache >= 1.7.10
- with-simple-cache >= 0.16.2
- add uni-time bad-practice to dates-and-times
- bump declapract peer dep to >= 0.13.22 for ifPresent support
- remove simple-in-memory-cache from config best-practice (now in cache)
- update depcheckrc and domain package.json

---
🐢🌊 surfed in by seaturtle[bot]