### PR TITLE
fix(config): add bastion and cluster to database.tunnel schema

### DIFF
--- a/src/practices/persist-with-rds/best-practice/config/prep.json
+++ b/src/practices/persist-with-rds/best-practice/config/prep.json
@@ -15,6 +15,8 @@
       }
     },
     "tunnel": {
+      "bastion": "vpc-main-bastion",
+      "cluster": "@declapract{variable.databaseName}",
       "local": {
         "host": "@declapract{variable.databaseTunnelHost.prep}",
         "port": 15432

--- a/src/practices/persist-with-rds/best-practice/config/prod.json
+++ b/src/practices/persist-with-rds/best-practice/config/prod.json
@@ -15,6 +15,8 @@
       }
     },
     "tunnel": {
+      "bastion": "vpc-main-bastion",
+      "cluster": "@declapract{variable.databaseName}",
       "local": {
         "host": "@declapract{variable.databaseTunnelHost.prod}",
         "port": 15433

--- a/src/practices/persist-with-rds/best-practice/config/test.json
+++ b/src/practices/persist-with-rds/best-practice/config/test.json
@@ -15,6 +15,8 @@
       }
     },
     "tunnel": {
+      "bastion": "vpc-main-bastion",
+      "cluster": "@declapract{variable.databaseName}",
       "local": {
         "host": "localhost",
         "port": 7821

--- a/src/practices/persist-with-rds/best-practice/src/utils/config/config.schema.ts
+++ b/src/practices/persist-with-rds/best-practice/src/utils/config/config.schema.ts
@@ -26,6 +26,8 @@ export const schema = z.object({
       }),
     }),
     tunnel: z.object({
+      bastion: z.string(),
+      cluster: z.string(),
       local: z.object({
         host: z.string(),
         port: z.number(),

--- a/src/practices/persist-with-rds/best-practice/src/utils/config/config.schema.ts.declapract.ts
+++ b/src/practices/persist-with-rds/best-practice/src/utils/config/config.schema.ts.declapract.ts
@@ -18,6 +18,8 @@ const databaseSchema = `  database: z.object({
       }),
     }),
     tunnel: z.object({
+      bastion: z.string(),
+      cluster: z.string(),
       local: z.object({
         host: z.string(),
         port: z.number(),


### PR DESCRIPTION
fix(config): add bastion and cluster to database.tunnel schema

- add bastion and cluster fields to tunnel zod schema
- add bastion and cluster to config JSON templates
- enables ghlitch use.rds.capacity to read these fields

closes ehmpathy/declapract-typescript-ehmpathy#496

---
🐢🌊 surfed in by seaturtle[bot]