### PR TITLE
fix(cicd-service): add prepare:rhachet step to deploy-sls assure job

### DIFF
--- a/.agent/repo=.this/role=any/briefs/declapract-default-check-equals.md
+++ b/.agent/repo=.this/role=any/briefs/declapract-default-check-equals.md
@@ -1,0 +1,52 @@
+# declapract default check equals
+
+## .what
+
+when a best-practice file has no explicit `.declapract.ts` companion, declapract uses `FileCheckType.EQUALS` by default.
+
+## .why
+
+- most best-practice files should match exactly
+- reduces boilerplate — no need to create `.declapract.ts` for every file
+- explicit `.declapract.ts` files are only needed when:
+  - `CONTAINS` or `EXISTS` check types are required
+  - custom check logic via `FileCheckFunction`
+  - custom fix logic via `FileFixFunction`
+
+## .examples
+
+### implicit equals (no .declapract.ts needed)
+
+```
+best-practice/
+├── .github/workflows/.deploy-sls.yml    # checked with EQUALS by default
+├── tsconfig.json                         # checked with EQUALS by default
+└── biome.json                            # checked with EQUALS by default
+```
+
+declapract compares target files to these templates byte-for-byte.
+
+### explicit check (requires .declapract.ts)
+
+```
+best-practice/
+├── package.json                          # pattern file with @declapract{...} syntax
+└── package.json.declapract.ts            # CONTAINS check for partial match
+```
+
+```typescript
+// package.json.declapract.ts
+import { FileCheckType } from 'declapract';
+
+export const check = FileCheckType.CONTAINS;
+```
+
+## .when to create .declapract.ts
+
+| need | create .declapract.ts? |
+|------|------------------------|
+| exact file match | no — default EQUALS |
+| partial content match | yes — use CONTAINS |
+| file existence only | yes — use EXISTS |
+| custom validation | yes — use FileCheckFunction |
+| custom fix logic | yes — export fix function |

--- a/src/practices/cicd-service/best-practice/.github/workflows/.deploy-sls.yml
+++ b/src/practices/cicd-service/best-practice/.github/workflows/.deploy-sls.yml
@@ -90,6 +90,11 @@ jobs:
           key: ${{ needs.install.outputs.node-modules-cache-key }}
           fail-on-cache-miss: true
 
+      # .why = keyrack.yml can extend other manifests via symlinks (e.g., .agent/repo=ehmpathy/role=mechanic/keyrack.yml)
+      #        prepare:rhachet creates these symlinks so keyrack.source() can hydrate extended keys
+      - name: prepare:rhachet
+        run: npm run prepare:rhachet --if-present
+
       - name: vpc:tunnel:open
         if: inputs.needs-vpn-for-acceptance
         run: ACCESS=${{ inputs.stage }} .agent/repo=.this/skills/use.vpc.tunnel.ts


### PR DESCRIPTION
fix(cicd-service): add prepare:rhachet step to deploy-sls assure job

- assure job runs test:acceptance which needs keyrack.yml symlinks hydrated
- prepare:rhachet creates these symlinks before acceptance tests run
- matches pattern from .test.yml integration/acceptance test jobs
- add brief documenting default FileCheckType.EQUALS behavior

---
🐢🌊 surfed in by seaturtle[bot]