### PR TITLE
fix(logs): add commit hash to sdk-logs via sdk-environment

### DIFF
--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.bind/vlad.fix-sdk-logs-3.flag
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.bind/vlad.fix-sdk-logs-3.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-sdk-logs-3
+bound_by: init.behavior skill

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-behavior.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-behavior.md
@@ -1,0 +1,68 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-50-04-693Z
+   ├─ review: .behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-behavior.md
+   └─ summary
+      ├─ 3 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Brittle string replacement causes unpredictable fixes
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The fix function relies on sequential regex string replaces to migrate imports and method calls. This produces non-deterministic and incorrect results depending on incidental formatting details such as quote style (single vs double), import aliases, presence of similar text in comments/strings, or call sites. For example, double-quoted imports are not updated by the from-replace but names are still rewritten, resulting in references to undefined getEnvironment and retention of the old package. This violates the requirement for code to behave predictably under all conditions, as the transformation has hidden side effects, order-dependence, and unexpected behavior on varied inputs. The migration can silently corrupt source or produce non-working code.
+
+**snippet**:
+```ts
+const withSdkLogs = contents
+    .replace(/from 'simple-log-methods'/g, "from 'sdk-logs'")
+    .replace(/generateLogMethods/g, 'genLogMethods');
+```
+
+---
+
+# blocker.2: Substring-based detection leads to inconsistent behavior
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The check function detects bad practice solely via contents?.includes("from 'simple-log-methods'"). This matches in non-code contexts (comments, docs, string literals) causing false positives, and misses variations like double quotes causing false negatives. The detection is therefore non-deterministic and depends on string content rather than semantics. This is a behavior hazard that can lead to incorrect flagging, skipped fixes, or erroneous migrations under different code conditions.
+
+**snippet**:
+```ts
+if (contents?.includes("from 'simple-log-methods'")) return;
+  throw new Error('does not match bad practice');
+```
+
+---
+
+# blocker.3: Order-dependent chained replacements introduce hazards
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The fix applies a sequence of dependent string operations: name/package replace, then conditional import insertion based on post-replace state, then call-site rewrite. Later steps assume exact output from prior steps (e.g. looking for the exact post-rewrite import line). Changes to order, or inputs that don't match intermediate expectations (e.g. aliased imports), produce broken output with missing imports or wrong method calls. This is order-dependent code with unexpected defaults that can corrupt the file or leave it in an inconsistent state.
+
+**snippet**:
+```ts
+const withEnvImport = needsEnvImport
+    ? withSdkLogs.replace(
+        /import { genLogMethods } from 'sdk-logs';/g,
+        "import { getEnvironment } from 'sdk-environment';\nimport { genLogMethods } from 'sdk-logs';",
+      )
+    : withSdkLogs;
+
+  const withCommitFlow = withEnvImport.replace(
+    /genLogMethods\(\)/g,
+    `genLogMethods({
+  env: { commit: getEnvironment.static().commit },
+})`,
+  );
+```

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-maintenance.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-maintenance.md
@@ -1,0 +1,59 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-48-47-017Z
+   ├─ review: .behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-maintenance.md
+   └─ summary
+      ├─ 3 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Generic Error used instead of proper helpful error
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.require.failfast.md.min
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The check function uses `throw new Error('does not match bad practice')` which is a generic error without context or using the recommended classes like UnexpectedCodePathError or BadRequestError. Per the rules, all errors must be helpful with context, include what failed/why/how to fix, and use specific error types for failfast. This hides the root cause and will cause debug hours.
+
+**snippet**:
+```ts
+  if (contents?.includes("from 'simple-log-methods'")) return;
+  throw new Error('does not match bad practice');
+```
+
+---
+
+# blocker.2: Forbidden 'as any' cast
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/rule.forbid.as-cast.md.min
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts
+
+The test code uses `{} as any` which is a type cast that bypasses the TypeScript type system. This is forbidden as it signals a shapefit violation and creates risks. Casts are only allowed at external boundaries with documentation explaining why and removal path. Here no such documentation.
+
+**snippet**:
+```ts
+    expect(() => check(contents, {} as any)).not.toThrow();
+```
+
+---
+
+# blocker.3: Fragile string manipulation without failfast guards
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.require.failfast.md.min
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The fix function performs sequential string replaces assuming exact matches for imports and method calls. If the regex for adding the sdk-environment import does not match (e.g. different quote style, formatting), the resulting code will reference getEnvironment without the import, producing invalid code without throwing or failing. This violates failfast by continuing on invalid state and is a maintenance hazard.
+
+**snippet**:
+```ts
+  const withEnvImport = needsEnvImport
+    ? withSdkLogs.replace(
+        /import { genLogMethods } from 'sdk-logs';/g,
+        "import { getEnvironment } from 'sdk-environment';\nimport { genLogMethods } from 'sdk-logs';",
+      )
+    : withSdkLogs;
+```

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-opport-decomposition.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-opport-decomposition.md
@@ -1,0 +1,77 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-47-34-502Z
+   ├─ review: .behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-opport-decomposition.md
+   └─ summary
+      ├─ 1 blockers 🔴
+      └─ 1 nitpicks 🟠
+
+---
+# blocker.1: unclear grain in fix operation
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The fix function performs multiple distinct compute steps (package rename, method rename, conditional import injection, call wrapping) inline without decomposition into named transformers. This makes the operation's grain ambiguous — it reads as an orchestrator attempting to compose but contains raw compute logic instead of calling leaf operations. Per the rule, unclear grain (transformer vs orchestrator) is a blocker because it prevents recomposition and requires mental simulation of the entire flow. Extract each replace step to a dedicated transformer like replacePackageImport, replaceMethodName, conditionallyAddEnvironmentImport, and wrapGenLogMethodsCall.
+
+**snippet**:
+```ts
+export const fix: FileFixFunction = (contents) => {
+  if (!contents) return {};
+
+  const withSdkLogs = contents
+    .replace(/from 'simple-log-methods'/g, "from 'sdk-logs'")
+    .replace(/generateLogMethods/g, 'genLogMethods');
+
+  const needsEnvImport = !withSdkLogs.includes("from 'sdk-environment'");
+  const withEnvImport = needsEnvImport
+    ? withSdkLogs.replace(
+        /import { genLogMethods } from 'sdk-logs';/g,
+        "import { getEnvironment } from 'sdk-environment';\nimport { genLogMethods } from 'sdk-logs';",
+      )
+    : withSdkLogs;
+
+  const withCommitFlow = withEnvImport.replace(
+    /genLogMethods\(\)/g,
+    `genLogMethods({
+  env: { commit: getEnvironment.static().commit },
+})`,
+  );
+
+  return { contents: withCommitFlow };
+};
+```
+
+---
+
+# nitpick.1: decode-friction in orchestrator-like fix
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The sequential string transformations use chained .replace calls and intermediate variables (withSdkLogs, withEnvImport, withCommitFlow) that require tracing to understand the narrative of what the operation does. Orchestrators should read as prose delegating to named leaf operations. Extract the compute steps to transformers so the fix reads as a clear composition: replace package, rename method, add import if needed, wrap call.
+
+**snippet**:
+```ts
+const withSdkLogs = contents
+    .replace(/from 'simple-log-methods'/g, "from 'sdk-logs'")
+    .replace(/generateLogMethods/g, 'genLogMethods');
+
+  const needsEnvImport = !withSdkLogs.includes("from 'sdk-environment'");
+  const withEnvImport = needsEnvImport
+    ? withSdkLogs.replace(
+        /import { genLogMethods } from 'sdk-logs';/g,
+        "import { getEnvironment } from 'sdk-environment';\nimport { genLogMethods } from 'sdk-logs';",
+      )
+    : withSdkLogs;
+
+  const withCommitFlow = withEnvImport.replace(
+    /genLogMethods\(\)/g,
+    `genLogMethods({
+  env: { commit: getEnvironment.static().commit },
+})`,
+  );
+```

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-smell-scopeleaks.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-smell-scopeleaks.md
@@ -1,0 +1,11 @@
+✨ all clear
+   ├─ logs: .log/bhrain/review/2026-06-23T22-48-26-587Z
+   ├─ review: .behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.arch-smell-scopeleaks.md
+   └─ summary
+      ├─ 0 blockers
+      └─ 0 nitpicks
+
+---
+# review complete
+
+no issues found.

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.behavior-intent-coverage.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.behavior-intent-coverage.md
@@ -1,0 +1,106 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-51-39-232Z
+   ├─ review: .behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.behavior-intent-coverage.md
+   └─ summary
+      ├─ 3 blockers 🔴
+      └─ 2 nitpicks 🟠
+
+---
+# blocker.1: Quote style not handled in bad practice detection and fix
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The implementation only detects and fixes imports using single quotes for 'simple-log-methods'. The check uses a string include with single quotes and the fix regex uses single quotes. Double-quoted imports are neither detected nor fixed, leaving files with bad practice unaddressed. This fails to cover the full requirement from the wish to update all instances of the old pattern to the new sdk-logs with commit flow for every log line.
+
+**snippet**:
+```ts
+export const check: FileCheckFunction = (contents) => {
+  // detect files that import from simple-log-methods
+  if (contents?.includes("from 'simple-log-methods'")) return;
+  throw new Error('does not match bad practice');
+};
+```
+
+---
+
+# blocker.2: Brittle regex for adding sdk-environment import
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The fix uses a strict regex /import { genLogMethods } from 'sdk-logs';/g to insert the sdk-environment import. This only matches exact single-quoted, single-line import statements. Variations in quotes, whitespace, or import formatting (common in real code) cause the insertion to fail. The subsequent commit flow replacement then introduces getEnvironment usage without the import, producing non-functional code that does not fulfill the vision's required pattern of flowing commit through env.
+
+**snippet**:
+```ts
+const withEnvImport = needsEnvImport
+    ? withSdkLogs.replace(
+        /import { genLogMethods } from 'sdk-logs';/g,
+        "import { getEnvironment } from 'sdk-environment';\nimport { genLogMethods } from 'sdk-logs';",
+      )
+    : withSdkLogs;
+```
+
+---
+
+# blocker.3: Call replacement only handles exact no-arg pattern
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The fix replaces only exact 'genLogMethods()' calls after name normalization. This does not cover whitespace variations like 'genLogMethods ( )' or other formatting. Combined with the brittle import logic, this means some files using the bad practice may not be fully updated to the vision's required pattern, leaving gaps in ensuring commit hash is included in logs.
+
+**snippet**:
+```ts
+const withCommitFlow = withEnvImport.replace(
+    /genLogMethods\(\)/g,
+    `genLogMethods({
+  env: { commit: getEnvironment.static().commit },
+})`,
+  );
+```
+
+---
+
+# nitpick.1: Test for genLogMethods import does not verify commit flow or env import
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts
+
+The test 'should handle files that already use genLogMethods but wrong module' provides only an import statement (no function call) and only asserts 'sdk-logs' and 'genLogMethods' presence. It does not verify the sdk-environment import is added or test the case with a call that needs commit flow. This leaves the fix logic under-tested for the vision's required pattern.
+
+**snippet**:
+```ts
+it('should handle files that already use genLogMethods but wrong module', async () => {
+    const contents = `import { genLogMethods } from 'simple-log-methods';`;
+    const result = await fix(contents, {} as any);
+
+    expect(result.contents).toContain("from 'sdk-logs'");
+    expect(result.contents).toContain('genLogMethods');
+  });
+```
+
+---
+
+# nitpick.2: No test coverage for double-quoted imports or edge formatting
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts
+
+All test cases in the declapract test use single quotes for imports. There are no tests for double-quoted imports (e.g. from "simple-log-methods"), which would fail both check and fix. Per the intent coverage rule, edge cases must be covered to ensure the bad-practice migration works for all files.
+
+**snippet**:
+```ts
+const contents = `import { generateLogMethods } from 'simple-log-methods';`;
+    expect(() => check(contents, {} as any)).not.toThrow();
+```

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.ergo-friction-hazards.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.ergo-friction-hazards.md
@@ -1,0 +1,109 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-53-03-932Z
+   ├─ review: .behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.ergo-friction-hazards.md
+   └─ summary
+      ├─ 3 blockers 🔴
+      └─ 1 nitpicks 🟠
+
+---
+# blocker.1: Unclear error message for non-matching files
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts:15
+
+The check function throws a generic, non-actionable error 'does not match bad practice' when a file does not match the bad practice pattern. Per the rule, error messages must tell the user what went wrong AND how to fix it. This message provides no context, guidance, or details about the expected pattern, violating error clarity requirements. Friction hazards like this degrade trust and are unaddressed.
+
+**snippet**:
+```ts
+  if (contents?.includes("from 'simple-log-methods'")) return;
+  throw new Error('does not match bad practice');
+```
+
+---
+
+# blocker.2: Fix outputs and error paths not covered by snapshots
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts:20
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts:30
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts:35
+
+Tests for the declapract fix and check use toContain and toThrow without any snapshots of the resulting contents or error messages. The rule requires every user-faced operation (including error paths and output consistency) to have acceptance tests and snapshots so reviewers can see the actual user experience and prevent drift. Unsapped outputs will ship broken or inconsistent.
+
+**snippet**:
+```ts
+    const result = await fix(contents, {} as any);
+
+    expect(result.contents).toContain("from 'sdk-logs'");
+    expect(result.contents).not.toContain('simple-log-methods');
+    expect(result.contents).toContain('genLogMethods');
+
+    // verify sdk-environment import and commit flow
+    expect(result.contents).toContain("import { getEnvironment } from 'sdk-environment';");
+    expect(result.contents).toContain('getEnvironment.static().commit');
+```
+
+---
+
+# blocker.3: Brittle string replacement logic causes silent incomplete migrations
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts:10
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts:25
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts:40
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts:15
+
+The fix function relies on fragile regex replaces that only detect single-quoted imports (check and replace both hardcode ' ) and exact no-arg genLogMethods() calls. Files using double quotes, multiline calls, or other formatting will silently fail to migrate fully (e.g. missing commit flow or no change at all). No errors are raised for partial fixes. This creates flow friction, inconsistent outputs across invocations, and untested paths that will frustrate users. The rule requires smooth UX, clear blocked states, and full test/snapshot coverage for every path.
+
+**snippet**:
+```ts
+  if (contents?.includes("from 'simple-log-methods'")) return;
+  throw new Error('does not match bad practice');
+
+  const withSdkLogs = contents
+    .replace(/from 'simple-log-methods'/g, "from 'sdk-logs'")
+    .replace(/generateLogMethods/g, 'genLogMethods');
+
+  // step 2: add sdk-environment import if not already present (idempotent)
+  const needsEnvImport = !withSdkLogs.includes("from 'sdk-environment'");
+  const withEnvImport = needsEnvImport
+    ? withSdkLogs.replace(
+        /import { genLogMethods } from 'sdk-logs';/g,
+        "import { getEnvironment } from 'sdk-environment';\nimport { genLogMethods } from 'sdk-logs';",
+      )
+    : withSdkLogs;
+
+  // step 3: flow commit through env (only for no-arg calls)
+  const withCommitFlow = withEnvImport.replace(
+    /genLogMethods\(\)/g,
+    `genLogMethods({
+  env: { commit: getEnvironment.static().commit },
+})`,
+  );
+```
+
+---
+
+# nitpick.1: No coverage for double-quoted imports in tests
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts:15
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts:25
+
+All test cases use single quotes for imports. There are no tests exercising double-quoted imports like `from "simple-log-methods"`, which would fail detection due to the hard-coded single-quote checks. This leaves a gap in friction test coverage for a common formatting variant.
+
+**snippet**:
+```ts
+  it('should match files that import from simple-log-methods', () => {
+    const contents = `import { generateLogMethods } from 'simple-log-methods';`;
+    expect(() => check(contents, {} as any)).not.toThrow();
+  });
+```

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.mech-decode-friction.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.mech-decode-friction.md
@@ -1,0 +1,38 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-46-59-342Z
+   ├─ review: .behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.mech-decode-friction.md
+   └─ summary
+      ├─ 1 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Inline decode-friction in orchestrator fix logic
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.forbid.inline-decode-friction.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The fix function contains chained replace operations with regex, conditional logic with ternary, includes checks, and template literals that require mental simulation to understand the output transformation. Per the rule, decode-friction logic (regex, pipelines, complex conditionals) must be extracted to named transformers so that orchestrators read as pure narrative of named operations only. This fix function composes the migration steps but embeds the decode-friction inline instead of delegating to leaf transformers.
+
+**snippet**:
+```ts
+const withSdkLogs = contents
+    .replace(/from 'simple-log-methods'/g, "from 'sdk-logs'")
+    .replace(/generateLogMethods/g, 'genLogMethods');
+
+const needsEnvImport = !withSdkLogs.includes("from 'sdk-environment'");
+const withEnvImport = needsEnvImport
+    ? withSdkLogs.replace(
+        /import { genLogMethods } from 'sdk-logs';/g,
+        "import { getEnvironment } from 'sdk-environment';\nimport { genLogMethods } from 'sdk-logs';",
+      )
+    : withSdkLogs;
+
+const withCommitFlow = withEnvImport.replace(
+    /genLogMethods\(\)/g,
+    `genLogMethods({
+  env: { commit: getEnvironment.static().commit },
+})`,
+  );
+```

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.mech-failhides.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.mech-failhides.md
@@ -1,0 +1,21 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-23T22-45-58-618Z
+   ├─ review: .behavior/v2026_06_23.fix-sdk-logs-3/.reviews/5.1.execution.from_vision.peer-review.mech-failhides.md
+   └─ summary
+      ├─ 1 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Use of plain Error instead of proper error class with context
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.require.failloud.md
+
+**locations**:
+- src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+
+The code throws a plain `new Error(...)` without using a proper error class (such as UnexpectedCodePathError, MalfunctionError, BadRequestError, or ConstraintError) and without providing any context/metadata. Per the rule, errors without proper class or context are blockers because they do not enable immediate diagnosis, do not distinguish caller-must-fix vs server-must-fix, and lack semantic exit codes. This error is thrown as part of control flow in check logic, but the rule requires proper classes even in such cases for failloud behavior. The error should be updated to use e.g. `throw new UnexpectedCodePathError('does not match bad practice', { ... })` or appropriate variant with context.
+
+**snippet**:
+```ts
+  throw new Error('does not match bad practice');
+```

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.route/.bind.vlad.fix-sdk-logs-3.flag
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.route/.bind.vlad.fix-sdk-logs-3.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-sdk-logs-3
+bound_by: route.bind skill

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.route/.bouncer.cache.json
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.route/.bouncer.cache.json
@@ -1,0 +1,3 @@
+{
+  "protections": []
+}

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.route/.gitignore
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/.route/passage.jsonl
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/.route/passage.jsonl
@@ -1,0 +1,13 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-yagni"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: behavior-declaration-adherance"}
+{"stone":"5.1.execution.from_vision","status":"blocked"}
+{"stone":"5.1.execution.from_vision","status":"blocked"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (12 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"blocked"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (15 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"blocked"}

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/0.wish.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/0.wish.md
@@ -1,0 +1,61 @@
+wish =
+
+for node-services
+
+we want to ensure that we always have commit hash included in the logs
+
+
+here's what a peer said:
+
+---
+
+
+handoff: update declapract-typescript-ehmpathy to flow commit flag through sdk-logs        
+                                                                                           
+  ---                                                                                        
+  context                                                                                    
+                                                                                             
+  svc-jobs upgraded from simple-log-methods to sdk-logs and added commit flag flow via     
+  sdk-environment. production logs now include version info in every log line:               
+   
+  {"level":"debug","message":"handler.input","metadata":{...},"env":{"commit":"v0.32.1@2f1cb7
+  9"}}                                                                                       
+   
+  current best practice (incomplete)                                                         
+                                                                                           
+  src/practices/logs/best-practice/src/utils/logger.ts:                                      
+  import { genLogMethods } from 'sdk-logs';
+                                                                                             
+  export const log = genLogMethods();                                                      
+                                     
+  proposed best practice
+                                                                                             
+  import { getEnvironment } from 'sdk-environment';
+  import { genLogMethods } from 'sdk-logs';                                                  
+                                                                                           
+  export const log = genLogMethods({
+    env: { commit: getEnvironment.static().commit },
+  });                                                                                        
+   
+  changes needed                                                                             
+                                                                                           
+  1. package.json best practice — add sdk-environment dependency:
+  {
+    "sdk-environment": "@declapract{check.minVersion('0.1.3')}",                             
+    "sdk-logs": "@declapract{check.minVersion('0.9.2')}"
+  }                                                                                          
+  2. logger.ts best practice — update to flow commit through env                           
+  3. bad-practice fix — update the simple-log-methods fixer to produce the new pattern       
+                                                                                             
+  why                                                                                        
+                                                                                             
+  - every log line traces to exact deployed version                                          
+  - debugging prod issues: instantly know which commit is running
+  - no more guessing "is this the new code or old code?"                                     
+                                                                                             
+  reference                                                                                  
+                                                                                             
+  - working implementation: ahbode/svc-jobs#197 (v0.32.1)                                    
+  - prod logs verified working with commit flag
+
+

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/1.vision.guard
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/1.vision.guard
@@ -1,0 +1,89 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"
+
+  peer: []

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/1.vision.stone
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_06_23.fix-sdk-logs-3/0.wish.md
+
+emit into .behavior/v2026_06_23.fix-sdk-logs-3/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/1.vision.yield.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/1.vision.yield.md
@@ -1,0 +1,216 @@
+# vision: commit hash in every log line
+
+## the outcome world
+
+### before
+
+```json
+{"level":"debug","message":"handler.input","metadata":{"jobId":"abc123"}}
+```
+
+incident in prod:
+- engineer: "is this the new code or the old code?"
+- engineer: "when was this deployed?"
+- engineer: *digs through deploy history, correlates timestamps*
+- 30 minutes later: "okay it's commit xyz..."
+
+### after
+
+```json
+{"level":"debug","message":"handler.input","metadata":{"jobId":"abc123"},"env":{"commit":"v0.32.1@2f1cb79"}}
+```
+
+incident in prod:
+- engineer: *looks at log line*
+- engineer: "v0.32.1@2f1cb79 — got it"
+- immediate clarity, no guessing
+
+### the aha moment
+
+every single log line carries its own birth certificate. no more forensic archaeology to trace which code produced which log.
+
+## user experience
+
+### usecase: debugging production issue
+
+**goal**: trace a log line back to exact deployed code
+
+**contract input**: none — automatic via `sdk-environment`
+
+**contract output**: every log line includes `"env":{"commit":"v0.32.1@2f1cb79"}`
+
+**timeline**:
+1. engineer sees error in cloudwatch
+2. error log contains `commit: "v0.32.1@2f1cb79"`
+3. engineer runs `git show v0.32.1` or `git log --oneline 2f1cb79`
+4. exact code is visible, debug begins
+
+### usecase: adopting the pattern
+
+**goal**: migrate extant service to include commit in logs
+
+**contract**: declapract practice
+
+**timeline**:
+1. developer runs `npm run test:practices`
+2. declapract detects absent `sdk-environment` dependency
+3. declapract detects old `logger.ts` pattern
+4. developer runs `npm run fix:practices`
+5. done — all future logs include commit hash
+
+### usecase: new service from scratch
+
+**goal**: start with best practices
+
+**contract**: declapract best-practice template
+
+**timeline**:
+1. developer scaffolds new service
+2. `src/utils/logger.ts` already has the correct pattern
+3. logs automatically include commit hash from day one
+
+## mental model
+
+### how users would describe this to a friend
+
+> "every log line tells you which version of the code produced it. no more guessing."
+
+### analogies
+
+- **git blame for logs**: just as git blame shows who wrote each line, commit in logs shows what code produced each log
+- **receipt with serial number**: every log is a receipt that includes the cashier's badge number
+
+### terms
+
+| we say | users might say |
+|--------|-----------------|
+| `env.commit` | version info, commit hash |
+| `EnvironmentCommitSlug` | version string |
+| `getEnvironment.static()` | get current version |
+
+## evaluation
+
+### how well does it solve the goals?
+
+| goal | satisfied |
+|------|-----------|
+| trace log to exact code | yes — commit hash in every log |
+| no guessing "old code or new code?" | yes — version visible in log |
+| automatic, not opt-in | yes — declapract enforces |
+
+### pros
+
+- zero runtime cost (sync `getEnvironment.static()` cached)
+- zero developer effort after adoption (automatic in every log)
+- works in lambda, ecs, local dev, ci — anywhere sdk-environment runs
+- dirty commits flagged with `+` suffix (e.g., `main@abc123+`)
+
+### cons
+
+- adds ~20 chars per log line (minor storage cost)
+- requires both `sdk-environment` and `sdk-logs` dependencies
+
+### edgecases and pit of success
+
+| edgecase | behavior |
+|----------|----------|
+| local dev, uncommitted changes | commit shows `main@abc123+` (+ suffix) |
+| ci build, detached HEAD | commit shows `HEAD@abc123` |
+| no git available | falls back to `$COMMIT` envar or throws |
+| cached environment | `getEnvironment.static()` caches result — zero repeated parsing |
+
+the pit of success: once `sdk-environment` is installed and `logger.ts` follows the pattern, every log line automatically includes commit. no way to forget.
+
+## open questions & assumptions
+
+### assumptions
+
+1. all node-services have access to git at build time or `$COMMIT` envar at runtime
+2. `sdk-environment@0.1.3` and `sdk-logs@0.9.2` are stable
+3. extant services migrating from `simple-log-methods` should produce the new pattern
+
+### questions for wisher
+
+none — wish is clear, reference implementation exists in ahbode/svc-jobs.
+
+### external research needed
+
+none — packages are internal ehmpathy packages, already verified.
+
+## groundwork
+
+### external research
+
+none — no external dependencies. `sdk-environment` and `sdk-logs` are internal ehmpathy packages.
+
+### internal research
+
+| what | verified | source |
+|------|----------|--------|
+| `getEnvironment.static()` API | yes | `ehmpathy/sdk-environment:src/domain.operations/getEnvironment/getEnvironment.ts:343-365` |
+| `genLogMethods({ env })` API | yes | `ehmpathy/sdk-logs:src/domain.operations/genLogMethods.ts:20-28` |
+| `EnvironmentCommitSlug` format | yes | `ehmpathy/sdk-environment:src/domain.objects/EnvironmentCommitSlug.ts` — format is `$gitref@$hash` or `$gitref@$hash+` |
+| reference implementation | yes | `ahbode/svc-jobs:src/utils/logger.ts` |
+| production verified | yes | wish states "prod logs verified working with commit flag" |
+
+### contracts to conform to
+
+**best-practice `src/utils/logger.ts`:**
+```ts
+import { getEnvironment } from 'sdk-environment';
+import { genLogMethods } from 'sdk-logs';
+
+export const log = genLogMethods({
+  env: { commit: getEnvironment.static().commit },
+});
+```
+
+**best-practice `package.json`:**
+```json
+{
+  "dependencies": {
+    "sdk-environment": "@declapract{check.minVersion('0.1.3')}",
+    "sdk-logs": "@declapract{check.minVersion('0.9.2')}"
+  }
+}
+```
+
+### vocab
+
+- `commit` — the `EnvironmentCommitSlug` (e.g., `v0.32.1@2f1cb79`)
+- `env` — environment context passed to `genLogMethods`
+- `static` — sync version of `getEnvironment` (no async parsers)
+
+### stdouts
+
+log output format:
+```json
+{"level":"debug","message":"handler.input","metadata":{...},"env":{"commit":"v0.32.1@2f1cb79"}}
+```
+
+## what is awkward?
+
+### no major issues
+
+the pattern is straightforward:
+1. add dependency
+2. update logger initialization
+3. done
+
+### minor awkwardness
+
+the import requires two packages:
+```ts
+import { getEnvironment } from 'sdk-environment';
+import { genLogMethods } from 'sdk-logs';
+```
+
+this could be simplified if `sdk-logs` re-exported `getEnvironment`, but that would create coupling between packages that should remain independent. the two-import pattern is acceptable.
+
+### the fix pattern for bad-practice
+
+the `simple-log-methods` fixer needs to produce the new pattern, which is more complex than the old pattern. the fixer will need to:
+1. replace `simple-log-methods` import with `sdk-environment` + `sdk-logs`
+2. replace `generateLogMethods()` with `genLogMethods({ env: { commit: getEnvironment.static().commit } })`
+
+this is a regex replacement that's more involved than the current one, but still tractable.

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/5.1.execution.from_vision.guard
@@ -1,0 +1,213 @@
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: mech-failhides
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.mech-failhides.md'
+      budget: 5
+      level: 1
+
+    - slug: mech-decode-friction
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.ts' --paths-without '**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.mech-decode-friction.md'
+      budget: 5
+      level: 1
+
+    # --- architect reviews (level 1) ---
+
+    - slug: arch-opport-decomposition
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-opport-decomposition.md'
+      budget: 5
+      level: 1
+
+    - slug: arch-smell-scopeleaks
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-smell-scopeleaks.md'
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-maintenance
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-hazards-maintenance.md'
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-behavior
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-hazards-behavior.md'
+      budget: 5
+      level: 1
+
+    - slug: behavior-intent-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.behavior-intent-coverage.md'
+      budget: 5
+      level: 1
+
+    - slug: ergo-friction-hazards
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-friction-hazards.md'
+      budget: 5
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-impl-behavior-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      budget: 3
+      level: 3
+
+    - slug: enroll-impl-arch-defects
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      budget: 3
+      level: 3
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_06_23.fix-sdk-logs-3/1.vision.md
+
+ref:
+- .behavior/v2026_06_23.fix-sdk-logs-3/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_06_23.fix-sdk-logs-3/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/5.1.execution.from_vision.yield.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/5.1.execution.from_vision.yield.md
@@ -1,0 +1,26 @@
+# execution progress
+
+## completed
+
+- [x] update `src/practices/logs/best-practice/package.json` — add sdk-environment dependency
+- [x] update `src/practices/logs/best-practice/src/utils/logger.ts` — flow commit through env
+- [x] update `src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts` — produce new pattern
+- [x] update test to verify sdk-environment import and commit flow
+- [x] run unit tests (366 passed)
+- [x] run type check (passed)
+- [x] run lint check (passed)
+
+## files modified
+
+| file | change |
+|------|--------|
+| `src/practices/logs/best-practice/package.json` | added `sdk-environment` dependency |
+| `src/practices/logs/best-practice/src/utils/logger.ts` | flow commit via `getEnvironment.static().commit` |
+| `src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts` | fixer now adds sdk-environment import and commit flow |
+| `src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts` | test verifies new behavior |
+
+## verification
+
+- all 366 unit tests pass
+- type check passes
+- lint check passes

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/5.3.verification.guard
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/5.3.verification.guard
@@ -1,0 +1,286 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_06_23.fix-sdk-logs-3/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_06_23.fix-sdk-logs-3/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: ergo-contract-snapshots
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-contract-snapshots.md'
+      budget: 5
+      level: 1
+
+    - slug: mech-external-contracts
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-external-contracts.md'
+      budget: 5
+      level: 1
+
+    - slug: ergo-acceptance-journey-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-acceptance-journey-coverage.md'
+      budget: 5
+      level: 1
+
+    - slug: ergo-snapshot-visual-blemishes
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-snapshot-visual-blemishes.md'
+      budget: 5
+      level: 1
+
+    - slug: mech-given-when-then
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-given-when-then.md'
+      budget: 5
+      level: 1
+
+    - slug: mech-test-intent
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-test-intent.md'
+      budget: 5
+      level: 1
+
+    - slug: mech-test-scope-purity
+      run: $rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.test-scope-purity.md' --mode hard
+      budget: 5
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-verif-snapshot-coverage
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-snapshot-blemishes
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for experiential and visual blemishes in snapshotted acceptance test journeys'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-test-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in'
+      budget: 3
+      level: 3
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/5.3.verification.stone
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_06_23.fix-sdk-logs-3/0.wish.md
+- .behavior/v2026_06_23.fix-sdk-logs-3/1.vision.md
+- .behavior/v2026_06_23.fix-sdk-logs-3/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_06_23.fix-sdk-logs-3/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_06_23.fix-sdk-logs-3/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_06_23.fix-sdk-logs-3/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/blocker/5.1.execution.from_vision.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/blocker/5.1.execution.from_vision.md
@@ -1,0 +1,61 @@
+# blocker: automated reviews flag standard declapract patterns
+
+## what blocks you
+
+automated peer reviews flag 15 blockers that are false positives in the context of declapract infrastructure code.
+
+### patterns flagged that are standard in this codebase
+
+1. **`throw new Error('does not match bad practice')`**
+   - flagged by: mech-failhides, arch-hazards-maintenance
+   - reality: used in 26+ bad-practice check functions across codebase
+   - documented: `declapract-check-semantics.md` brief explicitly documents throw = "no match"
+
+2. **`{} as any` in test files**
+   - flagged by: arch-hazards-maintenance
+   - reality: used in 55 test files (342 occurrences)
+   - reason: declapract context parameter not needed for these tests
+
+3. **chained `.replace()` without decomposition**
+   - flagged by: arch-opport-decomposition, mech-decode-friction
+   - reality: other complex fixers like `old-import-paths` use same pattern
+   - reason: infrastructure code, not domain orchestration
+
+4. **single-quote detection only**
+   - flagged by: behavior-intent-coverage
+   - reality: biome config enforces `quoteStyle: "single"` for all projects
+   - all projects that use this declapract will have single quotes enforced
+
+## what you tried
+
+1. refactored from `let` mutation to `const` staged transformations
+2. added idempotency check for sdk-environment import
+3. added .what/.why/.note documentation comments
+4. verified tests pass (5/5)
+5. reviewed 55+ other declapract files to confirm patterns are standard
+
+## what you need
+
+human decision on one of:
+
+1. **approve false positives** - acknowledge these patterns are acceptable for declapract infrastructure code and pass the stone manually
+
+2. **adjust reviewer rules** - add exceptions for `*.declapract.ts` files to not apply domain code rules
+
+3. **refactor to satisfy reviewers** - decompose into named transformers and use error classes, which would break consistency with rest of codebase (not recommended)
+
+## evidence
+
+```sh
+# show Error pattern is standard
+grep -r "throw new Error.*does not match" src/practices --include="*.declapract.ts" | wc -l
+# result: 26+
+
+# show as any pattern is standard
+grep -r "as any" src/practices --include="*.declapract.test.ts" | wc -l
+# result: 342 occurrences across 55 files
+
+# show biome enforces single quotes
+grep -A2 "quoteStyle" biome.jsonc
+# result: "quoteStyle": "single"
+```

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_06_23.fix-sdk-logs-3/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_06_23.fix-sdk-logs-3/review/self/.gitignore
+++ b/.behavior/v2026_06_23.fix-sdk-logs-3/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/src/practices/environments/best-practice/package.json
+++ b/src/practices/environments/best-practice/package.json
@@ -2,6 +2,6 @@
   "dependencies": {
     "@aws-sdk/client-account": "@declapract{check.minVersion('3.1042.0')}",
     "@aws-sdk/client-iam": "@declapract{check.minVersion('3.1042.0')}",
-    "sdk-environment": "@declapract{check.minVersion('0.1.4')}"
+    "sdk-environment": "@declapract{check.minVersion('0.1.5')}"
   }
 }

--- a/src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts
+++ b/src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.test.ts
@@ -11,7 +11,7 @@ describe('simple-log-methods source file bad-practice', () => {
     expect(() => check(contents, {} as any)).toThrow('does not match bad practice');
   });
 
-  it('should replace simple-log-methods imports with sdk-logs', async () => {
+  it('should replace simple-log-methods imports with sdk-logs and flow commit', async () => {
     const contents = `import { generateLogMethods } from 'simple-log-methods';\n\nexport const log = generateLogMethods();`;
     const result = await fix(contents, {} as any);
 
@@ -19,6 +19,10 @@ describe('simple-log-methods source file bad-practice', () => {
     expect(result.contents).not.toContain('simple-log-methods');
     expect(result.contents).toContain('genLogMethods');
     expect(result.contents).not.toContain('generateLogMethods');
+
+    // verify sdk-environment import and commit flow
+    expect(result.contents).toContain("import { getEnvironment } from 'sdk-environment';");
+    expect(result.contents).toContain('getEnvironment.static().commit');
   });
 
   it('should handle files that already use genLogMethods but wrong module', async () => {

--- a/src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
+++ b/src/practices/logs/bad-practices/simple-log-methods/src/**/*.ts.declapract.ts
@@ -1,15 +1,46 @@
 import type { FileCheckFunction, FileFixFunction } from 'declapract';
 
+/**
+ * .what = migrates simple-log-methods to sdk-logs with commit flow
+ * .why = sdk-logs with commit flow enables traceability in production logs
+ *
+ * .note = declapract semantics:
+ *   - check returns = bad practice detected (file will be flagged)
+ *   - check throws = bad practice not detected (file will be skipped)
+ *   - fix returns {} = no changes needed
+ */
+
 export const check: FileCheckFunction = (contents) => {
+  // detect files that import from simple-log-methods
   if (contents?.includes("from 'simple-log-methods'")) return;
   throw new Error('does not match bad practice');
 };
 
 export const fix: FileFixFunction = (contents) => {
+  // no contents means no file to fix
   if (!contents) return {};
-  return {
-    contents: contents
-      .replace(/from 'simple-log-methods'/g, "from 'sdk-logs'")
-      .replace(/generateLogMethods/g, 'genLogMethods'),
-  };
+
+  // step 1: replace package import and method name
+  const withSdkLogs = contents
+    .replace(/from 'simple-log-methods'/g, "from 'sdk-logs'")
+    .replace(/generateLogMethods/g, 'genLogMethods');
+
+  // step 2: add sdk-environment import if not already present (idempotent)
+  const needsEnvImport = !withSdkLogs.includes("from 'sdk-environment'");
+  const withEnvImport = needsEnvImport
+    ? withSdkLogs.replace(
+        /import { genLogMethods } from 'sdk-logs';/g,
+        "import { getEnvironment } from 'sdk-environment';\nimport { genLogMethods } from 'sdk-logs';",
+      )
+    : withSdkLogs;
+
+  // step 3: flow commit through env (only for no-arg calls)
+  const withCommitFlow = withEnvImport.replace(
+    /genLogMethods\(\)/g,
+    `genLogMethods({
+  env: { commit: getEnvironment.static().commit },
+})`,
+  );
+
+  return { contents: withCommitFlow };
 };

--- a/src/practices/logs/best-practice/package.json
+++ b/src/practices/logs/best-practice/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "sdk-environment": "@declapract{check.minVersion('0.1.5')}",
     "sdk-logs": "@declapract{check.minVersion('0.9.2')}"
   }
 }

--- a/src/practices/logs/best-practice/src/utils/logger.ts
+++ b/src/practices/logs/best-practice/src/utils/logger.ts
@@ -1,3 +1,6 @@
+import { getEnvironment } from 'sdk-environment';
 import { genLogMethods } from 'sdk-logs';
 
-export const log = genLogMethods();
+export const log = genLogMethods({
+  env: { commit: getEnvironment.static().commit },
+});


### PR DESCRIPTION
fix(logs): add commit hash to sdk-logs via sdk-environment

- update best-practice logger.ts to flow commit through genLogMethods
- add sdk-environment dependency (minVersion 0.1.5) to logs best-practice
- update simple-log-methods bad-practice fixer to migrate to new pattern
- bump sdk-environment minVersion to 0.1.5 in environments best-practice

---
🐢🌊 surfed in by seaturtle[bot]