### PR TITLE
fix(cicd): pin npm publish upgrade to npm at 11 for oidc

### DIFF
--- a/.github/workflows/.publish-npm.yml
+++ b/.github/workflows/.publish-npm.yml
@@ -48,8 +48,8 @@ jobs:
           NPM_VERSION=$(npm --version)
           MIN_VERSION="11.5.1"
           if [ "$(printf '%s\n' "$MIN_VERSION" "$NPM_VERSION" | sort -V | head -n1)" != "$MIN_VERSION" ]; then
-            echo "npm $NPM_VERSION < $MIN_VERSION, will upgrade npm now to support oidc..."
-            npm install -g npm@latest
+            echo "npm $NPM_VERSION < $MIN_VERSION, will upgrade npm to the latest 11.x for oidc..."
+            npm install -g npm@11
           else
             echo "npm $NPM_VERSION >= $MIN_VERSION, ready to use!"
           fi

--- a/.radio
+++ b/.radio
@@ -1,0 +1,1 @@
+/home/vlad/git/.radio/ehmpathy/declapract-typescript-ehmpathy

--- a/src/practices/cicd-package/best-practice/.github/workflows/.publish-npm.yml
+++ b/src/practices/cicd-package/best-practice/.github/workflows/.publish-npm.yml
@@ -48,8 +48,8 @@ jobs:
           NPM_VERSION=$(npm --version)
           MIN_VERSION="11.5.1"
           if [ "$(printf '%s\n' "$MIN_VERSION" "$NPM_VERSION" | sort -V | head -n1)" != "$MIN_VERSION" ]; then
-            echo "npm $NPM_VERSION < $MIN_VERSION, will upgrade npm now to support oidc..."
-            npm install -g npm@latest
+            echo "npm $NPM_VERSION < $MIN_VERSION, will upgrade npm to the latest 11.x for oidc..."
+            npm install -g npm@11
           else
             echo "npm $NPM_VERSION >= $MIN_VERSION, ready to use!"
           fi


### PR DESCRIPTION
fix(cicd): pin npm publish upgrade to npm at 11 for oidc

- fixes issue 525
- verify-oidc-compat upgraded via npm@latest, which rolled to npm@12 and
  raised its node floor above the pinned .nvmrc node v22.21.0, breaking the
  prod publish transport with EBADENGINE
- pin to npm@11 which stays at or above 11.5.1 for oidc and needs only node
  >=22.9.0, so it never crosses the pinned node engine floor
- apply to both the cicd-package best-practice template and this repo

---
🐢🌊 surfed in by seaturtle[bot]